### PR TITLE
README: use new Selenium driver syntax.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,13 @@ require "cyperful/rspec" if CYPERFUL
 
 RSpec.configure do |config|
   # make sure we setup the browser-driver BEFORE Cyperful's setup
+  # Cyperful only supports Selenium + Chrome
+  Capybara.register_driver :selenium_chrome do |app|
+    options = Selenium::WebDriver::Chrome::Options.new(args: ["window-size=1400,1400"])
+    Capybara::Selenium::Driver.new(app, browser: :chrome, options:)
+  end
   config.prepend_before(:example, type: :system) do
-    # Cyperful only supports Selenium + Chrome
-    driven_by :selenium, using: :chrome, screen_size: [1400, 1400]
+    driven_by :selenium_chrome
   end
 
   # ...
@@ -69,7 +73,11 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   include Cyperful::Minitest::SystemTestHelper if CYPERFUL
 
   # Cyperful only supports Selenium + Chrome
-  driven_by :selenium, using: :chrome, screen_size: [1400, 1400]
+  Capybara.register_driver :selenium_chrome do |app|
+    options = Selenium::WebDriver::Chrome::Options.new(args: ["window-size=1400,1400"])
+    Capybara::Selenium::Driver.new(app, browser: :chrome, options:)
+  end
+  driven_by :selenium_chrome
 
   # ...
 end


### PR DESCRIPTION
Avoids deprecation warnings:
```
2024-05-20 14:14:07 INFO Selenium [:logger_info] Details on how to use and modify Selenium logger:
  https://selenium.dev/documentation/webdriver/troubleshooting/logging

2024-05-20 14:14:07 WARN Selenium [DEPRECATION] DriverFinder.path(options, service_class) is deprecated. Use DriverFinder.new(options, service).driver_path instead.
```

I also personally found the screen size declaration to be not useful (possibly doing nothing) so it could maybe be removed too.